### PR TITLE
Drop support Node.js v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ workflows:
   version: 2
   node-multi-build:
     jobs:
-      - node-v4
       - node-v6
       - node-v8
       - node-latest
@@ -34,10 +33,6 @@ jobs:
       # - run: npm test
       # - run: bash <(curl -s https://codecov.io/bash)
 
-  node-v4:
-    <<: *base
-    docker:
-      - image: node:4
   node-v6:
     <<: *base
     docker:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i -g seqpar
 ```
 
 ### Requirement
-- Node.js 4+
+- Node.js 6+
 
 ## Defint first batch file
 All batch files are named in `{GROUP}_name(.{ext})` (e.g. `000_init.js`, `01_lint.sh`, `999_failover`).


### PR DESCRIPTION
Node.js v4 reach EOL.
We should drop support unsupported version.